### PR TITLE
Fix CRevModel process function loop stride

### DIFF
--- a/src/viper/utils/CRevModel.cpp
+++ b/src/viper/utils/CRevModel.cpp
@@ -120,7 +120,7 @@ void CRevModel::Mute() {
 }
 
 void CRevModel::ProcessReplace(float *bufL, float *bufR, uint32_t size) {
-    for (uint32_t idx = 0; idx < size; idx++) {
+    for (uint32_t idx = 0; idx < size * 2; idx += 2) {
         float outL = 0.0;
         float outR = 0.0;
         float input = (bufL[idx] + bufR[idx]) * this->gain;


### PR DESCRIPTION
According to the decompilation result of `CRevModel_R::ProcessReplace`, the for loop should process two elements in the buffer array each time, rather than iterating over each element.

This also explains why `Reverberation::Process` sets `bufR = bufL + 1`.

This **MIGHT** fix the reverberation effect, although I haven't tried the change on my phone (haven't set up a Android build environment yet).

Below is my decompilation result with Ghidra for reference:

```cpp
/* CRevModel_R::ProcessReplace(float*, float*, int) */
void CRevModel_R::ProcessReplace(int *param_1,int param_2,int param_3,int param_4)
{
  // ... some variable definitions ...
  
  if ((*param_1 != 0) && (iVar5 = param_4 + -1, 0 < param_4)) {
    iVar3 = param_3 + 8;
    iVar4 = param_2 + 8;
    do {
      // Load value from param_2 (bufL) and param_3 (bufR)
      fVar12 = *(float *)(iVar4 + -8);
      fVar11 = *(float *)(iVar3 + -8);
      // ... some computations and write back result ...
      // Index variable increments by 8 bytes (2 floats) each time
      iVar3 = iVar3 + 8;
      iVar4 = iVar4 + 8;
    } while (iVar5 != -1);
  }
  return;
}
```