### PR TITLE
Fix Stereo3DSurround remainder handling

### DIFF
--- a/src/viper/utils/Stereo3DSurround.cpp
+++ b/src/viper/utils/Stereo3DSurround.cpp
@@ -28,14 +28,14 @@ void Stereo3DSurround::Process(float *samples, uint32_t size) {
     }
 
     if (remainder > 0) {
-        for (uint32_t i = pairs; i < pairs + remainder; i++) {
-            float a = samples[2 * i];
-            float b = samples[2 * i + 1];
+        for (uint32_t i = 4 * pairs; i < 2 * size; i += 2) {
+            float a = samples[i];
+            float b = samples[i + 1];
             float c = this->coeffLeft * (a + b);
             float d = this->coeffRight * (b - a);
 
-            samples[2 * i] = c - d;
-            samples[2 * i + 1] = c + d;
+            samples[i] = c - d;
+            samples[i + 1] = c + d;
         }
     }
 }


### PR DESCRIPTION
Fixes another issue I found while looking through not working effects.

`Stereo3DSurround::Process`'s code for handling pairs processed `4 * pairs` samples. The processing for remainders should start from `4 * pairs` instead of `2 * pairs`.

Again, this might fix stuff or it might not. Haven't tested on my phone.